### PR TITLE
Generate schemas.json instead of TOML version

### DIFF
--- a/aggregateur/main.py
+++ b/aggregateur/main.py
@@ -8,7 +8,7 @@ from notifications import EmailNotification
 from errors import ErrorBag, ErrorsCache
 
 import yaml
-import toml
+import json
 import giturlparse
 from semver import VersionInfo, cmp as SemverCmp
 from git import Repo as GitRepo
@@ -54,23 +54,25 @@ class Metadata(object):
         with open("data/schemas.yml", "w") as f:
             yaml.dump(self.get(), f, allow_unicode=True)
 
-        # Save in TOML
-        with open("data/schemas.toml", "w") as f:
-            toml.dump(self.generate_toml(), f)
+        # Save in JSON
+        with open("data/schemas.json", "w") as f:
+            json.dump(self.generate_json(), f)
 
-    def generate_toml(self):
-        toml_data = {}
+    def generate_json(self):
+        json_data = {
+            "$schema": "https://opendataschema.frama.io/catalog/schema-catalog.json",
+            "version": 1,
+        }
+        schemas = []
+
         for slug, details in self.data.items():
             if details["type"] != "tableschema":
                 continue
-            toml_data[slug] = {
-                "title": details["title"],
-                "description": details["description"],
-                "version": details["latest_version"],
-                "doc_url": "https://schema.data.gouv.fr/%s/latest.html" % slug,
-                "schema": self.schema_url(slug),
-            }
-        return toml_data
+            schemas.append({"name": slug, "schema_url": self.schema_url(slug)})
+
+        json_data["schemas"] = schemas
+
+        return json_data
 
 
 class Repo(object):

--- a/aggregateur/requirements.txt
+++ b/aggregateur/requirements.txt
@@ -6,6 +6,5 @@ PyYAML==5.1
 mailjet-rest==1.3.3
 python-frontmatter==0.4.5
 table_schema_to_markdown==0.3.1
-toml==0.10.0
 lxml==4.3.4
 jsonschema==3.0.1

--- a/web/collections/_documentation/integration-autres-systemes.md
+++ b/web/collections/_documentation/integration-autres-systemes.md
@@ -49,14 +49,18 @@ etalab/schema-irve:
   - 1.0.1
 ```
 
-Un extrait du fichier `schemas.toml` (accessible directement à l'adresse <https://schema.data.gouv.fr/schemas/schemas.toml>), permettant l'intégration avec [Validata](https://validata.fr) :
-```toml
-["etalab/schema-irve"]
-title = "Schéma IRVE"
-description = "Spécification du fichier d'échange relatif aux données concernant la localisation géographique et les caractéristiques techniques des stations et des points de recharge pour véhicules électriques"
-version = "1.0.1"
-doc_url = "https://schema.data.gouv.fr/etalab/schema-irve/latest.html"
-schema = "https://schema.data.gouv.fr/schemas/etalab/schema-irve/latest/schema.json"
+Un extrait du fichier `schemas.json` (accessible directement à l'adresse <https://schema.data.gouv.fr/schemas/schemas.json>), permettant l'intégration avec [Validata](https://validata.fr) :
+```json
+{
+    "$schema":"https://opendataschema.frama.io/catalog/schema-catalog.json",
+    "version":1,
+    "schemas":[
+        {
+            "name":"etalab/schema-decp-dpa",
+            "schema_url":"https://schema.data.gouv.fr/schemas/etalab/schema-decp-dpa/latest/schema.json"
+        }
+    ]
+}
 ```
 
 ## URLs stables


### PR DESCRIPTION
Will be published at https://schema.data.gouv.fr/schemas/schemas.json