### PR TITLE
infos-travaux: ajoute le schema dans repertoires.yml

### DIFF
--- a/aggregateur/repertoires.yml
+++ b/aggregateur/repertoires.yml
@@ -34,3 +34,7 @@ covoiturage:
   url: https://github.com/etalab/schema-lieux-covoiturage.git
   type: tableschema
   email: contact@transport.beta.gouv.fr
+infos-travaux:
+  url: https://github.com/metis-reseaux/infos-travaux.git
+  type: jsonschema
+  email: contact@gotmi.io


### PR DESCRIPTION
Bonjour,

Voici comme convenu la PR concernant le schema Informations Travaux.
Bonne relecture.

Bien cordialement,
Olivier Marcel