### PR TITLE
Only keep errors for recent or new tags

### DIFF
--- a/aggregateur/errors.py
+++ b/aggregateur/errors.py
@@ -64,5 +64,19 @@ class ErrorBag(object):
             raise ValueError(
                 "Exception should be a ValidationException got %s" % type(exception)
             )
-        self.errors_by_slug[exception.repo.slug].append(exception)
-        self.errors_by_email[exception.repo.email].append(exception)
+
+        no_valid_tag, greater_version = False, False
+        try:
+            latest_valid_tag = exception.repo.latest_valid_tag()
+            no_valid_tag = latest_valid_tag is None
+            greater_version = (
+                not no_valid_tag and exception.repo.current_tag > latest_valid_tag
+            )
+        except ValidationException:
+            pass
+
+        # Only keep exceptions related to repos without valid tags
+        # or if tag is more recent than the latest valid one
+        if no_valid_tag or greater_version:
+            self.errors_by_slug[exception.repo.slug].append(exception)
+            self.errors_by_email[exception.repo.email].append(exception)

--- a/aggregateur/notifications.py
+++ b/aggregateur/notifications.py
@@ -3,8 +3,6 @@ import os
 
 
 class EmailNotification(object):
-    EMAILS_BLACKLIST = ["info@data.gouv.fr"]
-
     def __init__(self, email_to, exceptions):
         super(EmailNotification, self).__init__()
         self.email_to = email_to
@@ -39,6 +37,4 @@ class EmailNotification(object):
         return Client(auth=(api_key, api_secret), version="v3.1")
 
     def should_send_email(self):
-        is_master = os.environ.get("CIRCLE_BRANCH", "nope") == "master"
-        no_blacklist = self.email_to not in self.EMAILS_BLACKLIST
-        return is_master and no_blacklist
+        return os.environ.get("CIRCLE_BRANCH", "nope") == "master"


### PR DESCRIPTION
Related to https://github.com/etalab/schema.data.gouv.fr/issues/29

Only keep exceptions related to repos without valid tags or if tag is more recent than the latest valid on.

Avoid sending notifications every 48 hours for old invalid versions.