### PR TITLE
Improve email message on error

### DIFF
--- a/aggregateur/notifications.py
+++ b/aggregateur/notifications.py
@@ -10,9 +10,15 @@ class EmailNotification(object):
 
     def send(self):
         errors = "\n".join(["- " + repr(e) for e in self.exceptions])
-        text = (
-            "Bonjour !\n\nDes erreurs sont survenues lors de la validation de vos schémas.\n\n%s\n\nMerci de corriger ces erreurs."
-            % errors
+        text = "\n\n".join(
+            [
+                "Bonjour,",
+                "Cet e-mail est envoyé suite à votre soumission de schéma sur schema.data.gouv.fr",
+                "Des erreurs sont survenues lors de la validation de vos schémas :",
+                errors,
+                "Merci de corriger ces erreurs. Une fois ces erreurs corrigées, vos modifications seront intégrées sans action supplémentaire de votre part",
+                "L'équipe de data.gouv.fr",
+            ]
         )
         data = {
             "Messages": [

--- a/aggregateur/notifications.py
+++ b/aggregateur/notifications.py
@@ -15,10 +15,10 @@ class EmailNotification(object):
         text = "\n\n".join(
             [
                 "Bonjour,",
-                "Cet e-mail est envoyé suite à votre soumission de schéma sur schema.data.gouv.fr",
+                "Cet e-mail est envoyé suite à votre soumission de schéma sur schema.data.gouv.fr.",
                 "Des erreurs sont survenues lors de la validation de vos schémas :",
                 errors,
-                "Merci de corriger ces erreurs. Une fois ces erreurs corrigées, vos modifications seront intégrées sans action supplémentaire de votre part",
+                "Merci de corriger ces erreurs. Une fois ces erreurs corrigées, vos modifications seront intégrées sans action supplémentaire de votre part.",
                 f"Vous pouvez consulter la documentation détaillant les validations effectuées sur les schémas : {self.VALIDATION_DOC_URL}.",
                 "L'équipe de data.gouv.fr",
             ]

--- a/aggregateur/notifications.py
+++ b/aggregateur/notifications.py
@@ -3,6 +3,8 @@ import os
 
 
 class EmailNotification(object):
+    VALIDATION_DOC_URL = "https://schema.data.gouv.fr/documentation/validation-schemas"
+
     def __init__(self, email_to, exceptions):
         super(EmailNotification, self).__init__()
         self.email_to = email_to
@@ -17,6 +19,7 @@ class EmailNotification(object):
                 "Des erreurs sont survenues lors de la validation de vos schémas :",
                 errors,
                 "Merci de corriger ces erreurs. Une fois ces erreurs corrigées, vos modifications seront intégrées sans action supplémentaire de votre part",
+                f"Vous pouvez consulter la documentation détaillant les validations effectuées sur les schémas : {self.VALIDATION_DOC_URL}.",
                 "L'équipe de data.gouv.fr",
             ]
         )

--- a/aggregateur/notifications.py
+++ b/aggregateur/notifications.py
@@ -18,8 +18,8 @@ class EmailNotification(object):
                 "Cet e-mail est envoyé suite à votre soumission de schéma sur schema.data.gouv.fr.",
                 "Des erreurs sont survenues lors de la validation de vos schémas :",
                 errors,
-                "Merci de corriger ces erreurs. Une fois ces erreurs corrigées, vos modifications seront intégrées sans action supplémentaire de votre part.",
-                f"Vous pouvez consulter la documentation détaillant les validations effectuées sur les schémas : {self.VALIDATION_DOC_URL}.",
+                "Merci de corriger ces erreurs. Vous pouvez soit créer un nouveau tag soit modifier le tag existant en intégrant vos corrections. Une fois ces erreurs corrigées, vos modifications seront intégrées sans action supplémentaire de votre part.",
+                f"Pour vous aider, vous pouvez consulter la documentation détaillant les validations effectuées sur les schémas : {self.VALIDATION_DOC_URL}.",
                 "L'équipe de data.gouv.fr",
             ]
         )


### PR DESCRIPTION
Related to https://github.com/etalab/schema.data.gouv.fr/issues/44

Hard to get a specific build URL for now on CircleCI. Build logs will not add new content for errors compared to what is already in the message.