### PR TITLE
correction orthotypo

### DIFF
--- a/web/collections/_documentation/validation-schemas.md
+++ b/web/collections/_documentation/validation-schemas.md
@@ -14,7 +14,7 @@ Cette page décrit comment sont validés les schémas avant leur intégration su
 Seuls les schémas considérés comme valides sont intégrés sur `schema.data.gouv.fr`. Si votre schéma comporte plusieurs versions, seules les versions valides seront automatiquement intégrées.
 
 Pour tous les types de schéma, il faut que :
-- votre schéma soit sur un dépôt Git, à raison d'un dépôt par schéma. Ce dépôt doit pouvoir être clôné depuis Internet sans authentification préalable ;
+- votre schéma soit sur un dépôt Git, à raison d'un dépôt par schéma. Ce dépôt doit pouvoir être cloné depuis Internet sans authentification préalable ;
 - votre dépôt Git doit comporter des tags indiquant les versions de votre schéma. Ces versions doivent respecter la [gestion sémantique de version semver](https://semver.org/lang/fr/), sous la forme `1.3.2` par exemple ;
 - votre dépôt doit comporter un fichier `README.md` à la racine contenant une documentation du schéma indiquant par exemple le contexte de production, la gouvernance ;
 - passer avec succès les tests spécifiques au type de schéma que votre dépôt contient.


### PR DESCRIPTION
clôné → cloné
https://www.cnrtl.fr/definition/clone