### PR TITLE
Fetch and store schema issues from GitHub API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,11 @@ jobs:
           command: |
             . venv/bin/activate
             python main.py
+      - run:
+          name: Fetch schema issues
+          command: |
+            . venv/bin/activate
+            python issues.py
       - persist_to_workspace:
           root: .
           paths:

--- a/aggregateur/issues.py
+++ b/aggregateur/issues.py
@@ -12,6 +12,7 @@ def prepare_issue(item):
         "created_at": item["created_at"],
         "url": item["html_url"],
         "nb_comments": item["comments"],
+        "labels": [l["name"] for l in item["labels"]],
     }
 
 

--- a/aggregateur/issues.py
+++ b/aggregateur/issues.py
@@ -1,0 +1,55 @@
+import requests
+import yaml
+
+GITHUB_API = "https://api.github.com"
+REPO = "etalab/schema.data.gouv.fr"
+PHASES = ["construction", "investigation"]
+
+
+def prepare_issue(item):
+    return {
+        "title": item["title"],
+        "created_at": item["created_at"],
+        "url": item["html_url"],
+        "nb_comments": item["comments"],
+    }
+
+
+def check_label_issues():
+    r = requests.get(f"{GITHUB_API}/repos/{REPO}/labels")
+    r.raise_for_status()
+
+    names = set()
+    found = 0
+    for label in r.json():
+        label_name = label["name"]
+        names.add(label_name)
+        for phase in PHASES:
+            if phase in label_name:
+                found += 1
+
+    if found != len(PHASES):
+        raise ValueError(
+            f"Could not find appropriate label names. Looking for various phases: {str(PHASES)}. Issue names: {str(names)}"
+        )
+
+
+check_label_issues()
+# See documentation:
+# https://developer.github.com/v3/issues/#list-issues-for-a-repository
+r = requests.get(f"{GITHUB_API}/repos/{REPO}/issues")
+r.raise_for_status()
+
+issues = {}
+for phase in PHASES:
+    issues[phase] = []
+data = r.json()
+
+for item in data:
+    for label in item["labels"]:
+        for phase in PHASES:
+            if phase in label["name"]:
+                issues[phase].append(prepare_issue(item))
+
+with open("data/issues.yml", "w") as f:
+    yaml.dump(issues, f, allow_unicode=True)

--- a/aggregateur/requirements.txt
+++ b/aggregateur/requirements.txt
@@ -8,3 +8,4 @@ python-frontmatter==0.4.5
 table_schema_to_markdown==0.3.1
 lxml==4.3.4
 jsonschema==3.0.1
+requests==2.22.0


### PR DESCRIPTION
Upcoming or in investigation schemas are declared on GitHub, in [the issues section](https://github.com/etalab/schema.data.gouv.fr/issues) of the current repo.

In order to display this information on schema.data.gouv.fr, we need to fetch issues from the GitHub API and store them. Next, we'll need to write a static Jekyll page using the fetched data to display this on the web.

This PR does the first step: fetching and storing issues in YAML. I'll write a follow-up PR to use this file and build a static page.

Here you can find an example file
```yaml
construction:
- created_at: '2019-12-05T16:05:41Z'
  nb_comments: 0
  title: schéma des informations de restauration collectivité
  url: https://github.com/etalab/schema.data.gouv.fr/issues/64
- created_at: '2019-12-05T15:09:47Z'
  nb_comments: 0
  title: schéma des actes budgétaires
  url: https://github.com/etalab/schema.data.gouv.fr/issues/63
investigation:
- created_at: '2019-11-16T23:26:52Z'
  nb_comments: 7
  title: Schéma des centres de secours
  url: https://github.com/etalab/schema.data.gouv.fr/issues/62
- created_at: '2019-06-17T10:02:08Z'
  nb_comments: 6
  title: description des schémas relationnels de nos géostandards
  url: https://github.com/etalab/schema.data.gouv.fr/issues/25

```