### PR TITLE
Page schémas en investigation et construction

### DIFF
--- a/web/_includes/issues.html
+++ b/web/_includes/issues.html
@@ -2,8 +2,8 @@
   {% for issue in include.issues %}
   <li>
     <a href="{{ issue.url }}">{{ issue.title }}</a>
-    {% if issue.nb_comments > 1 %}
-    - {{ issue.nb_comments }} commentaires
+    {% if issue.nb_comments > 0 %}
+    - {{ issue.nb_comments }} commentaire{% if issue.nb_comments > 1 %}s{% endif %}
     {% endif %}
     - créé le {{ issue.created_at | date: '%d/%m/%Y' }}
   </li>

--- a/web/_includes/issues.html
+++ b/web/_includes/issues.html
@@ -1,0 +1,11 @@
+<ul>
+  {% for issue in include.issues %}
+  <li>
+    <a href="{{ issue.url }}">{{ issue.title }}</a>
+    {% if issue.nb_comments > 1 %}
+    - {{ issue.nb_comments }} commentaires
+    {% endif %}
+    - créé le {{ issue.created_at | date: '%d/%m/%Y' }}
+  </li>
+  {% endfor %}
+</ul>

--- a/web/build.sh
+++ b/web/build.sh
@@ -5,6 +5,7 @@ wget https://github.com/etalab/schema.data.gouv.fr/archive/master.zip -O /tmp/sc
 unzip /tmp/schema.data.gouv.fr.zip -d /tmp
 cp -r /tmp/schema.data.gouv.fr-master/aggregateur/data/. collections/_schemas/
 cp /tmp/schema.data.gouv.fr-master/aggregateur/data/schemas.yml _data/
+cp /tmp/schema.data.gouv.fr-master/aggregateur/data/issues.yml _data/
 bundle exec jekyll build
 
 # Add headers' rules for Netlify

--- a/web/collections/_documentation/ajouter-un-schema.md
+++ b/web/collections/_documentation/ajouter-un-schema.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "Ajouter un schéma"
-order: 1
+order: 2
 ---
 # Ajouter un schéma
 

--- a/web/collections/_documentation/integration-autres-systemes.md
+++ b/web/collections/_documentation/integration-autres-systemes.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "Intégration avec d'autres systèmes"
-order: 3
+order: 4
 ---
 # Intégration avec d'autres systèmes
 En tant que plateforme de référencement de schémas, `schema.data.gouv.fr` a vocation à être facilement utilisée par d'autres systèmes informatiques. Nous proposons plusieurs éléments à cet effet.

--- a/web/collections/_documentation/schemas-investigation-construction.html
+++ b/web/collections/_documentation/schemas-investigation-construction.html
@@ -1,0 +1,55 @@
+---
+layout: page
+title: "Schémas en investigation et en cours de construction"
+order: 1
+---
+
+<h1>Schémas en investigation et en cours de construction</h1>
+
+<h2>Impliquer des producteurs et des réutilisateurs</h2>
+<p>
+  schema.data.gouv.fr permet de mettre en relation des producteurs de schémas et une communauté de producteurs ou de réutilisateurs. Vous envisagez de créer un schéma ? Vous êtes en phase d'élaboration d'un schéma ? schema.data.gouv.fr vous aide à communiquer sur cette démarche et recueillir des contributions.
+</p>
+
+<h2>Déclarer un schéma en phase d'élaboration</h2>
+<p>
+  Vous envisagez de créer un schéma ou vous en phase d'élaboration d'un schéma et vous souhaiter recueillir des retours de la part de la communauté. Vous pouvez déclarer cette initiative auprès de schema.data.gouv.fr :
+</p>
+<ul>
+  <li>
+    <a href="https://github.com/etalab/schema.data.gouv.fr/issues/new">En ouvrant un ticket sur GitHub</a> ;
+  </li>
+  <li>
+    En envoyant un e-mail à l'adresse <a href="mailto:schema@data.gouv.fr">schema@data.gouv.fr</a>.
+  </li>
+</ul>
+
+<p>
+  Votre schéma sera par la suite automatiquement référencé sur cette page.
+</p>
+
+<h2>Recensement des schémas en phase d'élaboration</h2>
+<p>
+  schema.data.gouv.fr recense sur cette page les schémas :
+</p>
+
+<ul>
+  <li><b>en investigation</b> : il est envisagé de créer un schéma pour modéliser une situation ;</li>
+  <li><b>en cours d'élaboration</b> : ce schéma fait l'objet de discussions auprès de multiples partenaires.</li>
+</ul>
+
+<h3>Schémas en investigation</h3>
+{% if site.data.issues.investigation.size == 0 %}
+  <p>Aucun schéma n'est en cours d'investigation actuellement.</p>
+{% else %}
+  <p>Les schémas suivants sont en cours d'investigation.</p>
+  {% include issues.html issues=site.data.issues.investigation %}
+{% endif %}
+
+<h3>Schémas en construction</h3>
+{% if site.data.issues.construction.size == 0 %}
+  <p>Aucun schéma n'est en cours de construction actuellement.</p>
+{% else %}
+  <p>Les schémas suivants sont en cours de construction.</p>
+  {% include issues.html issues=site.data.issues.construction %}
+{% endif %}

--- a/web/collections/_documentation/schemas-reglementaires.md
+++ b/web/collections/_documentation/schemas-reglementaires.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "Schémas réglementaires"
-order: 4
+order: 5
 ---
 Les schémas référencés sur `schema.data.gouv.fr` sont ceux dont l'existence est justifiée par voie réglementaire ou par voie d'usage. Voir la page [Ajouter un schéma](ajouter-un-schema.md) pour proposer l'ajout d'un schéma.
 

--- a/web/collections/_documentation/schemas-reglementaires.md
+++ b/web/collections/_documentation/schemas-reglementaires.md
@@ -3,6 +3,9 @@ layout: page
 title: "Schémas réglementaires"
 order: 5
 ---
+
+# Schémas réglementaires
+
 Les schémas référencés sur `schema.data.gouv.fr` sont ceux dont l'existence est justifiée par voie réglementaire ou par voie d'usage. Voir la page [Ajouter un schéma](ajouter-un-schema.md) pour proposer l'ajout d'un schéma.
 
 ## Textes réglementaires

--- a/web/collections/_documentation/validation-schemas.md
+++ b/web/collections/_documentation/validation-schemas.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "Validation des schémas"
-order: 2
+order: 3
 ---
 # Validation des schémas
 


### PR DESCRIPTION
Follow up de #68. On utilise le fichier YAML récupéré et sauvegardé dans la PR précédente pour construire automatiquement cette page.

Démonstration de la page obtenue : https://deploy-preview-74--schema-datagouv.netlify.com/documentation/schemas-investigation-construction