### PR TITLE
Rollback tableschema-py version

### DIFF
--- a/aggregateur/requirements.txt
+++ b/aggregateur/requirements.txt
@@ -1,7 +1,7 @@
 GitPython==3.0.7
 git-url-parse==1.2.2
 semver==2.9.1
-tableschema==1.13.1
+tableschema==1.12.4
 PyYAML==5.3
 mailjet-rest==1.3.3
 python-frontmatter==0.5.0


### PR DESCRIPTION
Following [this PR](https://github.com/frictionlessdata/tableschema-py/pull/268) which added constraints, some _nearly valid_ schemas (some fields were not used at the right place) were made invalid. This has the effect to unpublish schema.

This produced the following errors:

```
scdl@opendatafrance.email:
- InvalidSchemaException: [repo `scdl/budget` tag `0.2.0`]: Schema schema.json is not a valid TableSchema schema. Errors: ValidationError('Descriptor validation error: \'fields\' is a required property at "" in descriptor and at "required" in profile')
- InvalidSchemaException: [repo `scdl/budget` tag `0.2.1`]: Schema schema.json is not a valid TableSchema schema. Errors: ValidationError("field BGT_ANNEE: built-in pattern constraint can't be applied to integer type field"); ValidationError("field BGT_SIRET: built-in pattern constraint can't be applied to integer type field"); ValidationError("field BGT_NATURE: built-in pattern constraint can't be applied to integer type field"); ValidationError("field BGT_FONCTION: built-in pattern constraint can't be applied to integer type field")
- InvalidSchemaException: [repo `scdl/budget` tag `0.3.0`]: Schema schema.json is not a valid TableSchema schema. Errors: ValidationError("field BGT_ANNEE: built-in pattern constraint can't be applied to year type field"); ValidationError("field BGT_NATURE: built-in pattern constraint can't be applied to integer type field"); ValidationError("field BGT_FONCTION: built-in pattern constraint can't be applied to integer type field")
- InvalidSchemaException: [repo `scdl/budget` tag `0.4.0`]: Schema schema.json is not a valid TableSchema schema. Errors: ValidationError("field BGT_ANNEE: built-in pattern constraint can't be applied to year type field"); ValidationError("field BGT_NATURE: built-in pattern constraint can't be applied to integer type field"); ValidationError("field BGT_FONCTION: built-in pattern constraint can't be applied to integer type field")
- InvalidSchemaException: [repo `scdl/budget` tag `0.5.0`]: Schema schema.json is not a valid TableSchema schema. Errors: ValidationError("field BGT_ANNEE: built-in pattern constraint can't be applied to year type field"); ValidationError("field BGT_NATURE: built-in pattern constraint can't be applied to integer type field"); ValidationError("field BGT_FONCTION: built-in pattern constraint can't be applied to integer type field")
- InvalidSchemaException: [repo `scdl/budget` tag `0.5.1`]: Schema schema.json is not a valid TableSchema schema. Errors: ValidationError("field BGT_ANNEE: built-in pattern constraint can't be applied to year type field"); ValidationError("field BGT_NATURE: built-in pattern constraint can't be applied to integer type field"); ValidationError("field BGT_FONCTION: built-in pattern constraint can't be applied to integer type field")
- InvalidSchemaException: [repo `scdl/budget` tag `0.6.0`]: Schema schema.json is not a valid TableSchema schema. Errors: ValidationError("field BGT_ANNEE: built-in pattern constraint can't be applied to year type field")
- InvalidSchemaException: [repo `scdl/budget` tag `0.7.0`]: Schema schema.json is not a valid TableSchema schema. Errors: ValidationError("field BGT_ANNEE: built-in pattern constraint can't be applied to year type field")
- InvalidSchemaException: [repo `scdl/budget` tag `0.8.0`]: Schema schema.json is not a valid TableSchema schema. Errors: ValidationError("field BGT_ANNEE: built-in pattern constraint can't be applied to year type field")
contact@geodae.sante.gouv.fr:
- InvalidSchemaException: [repo `arsante/schema-dae` tag `1.0.0`]: Schema schema.json is not a valid TableSchema schema. Errors: ValidationError("field dtpr_bat: built-in pattern constraint can't be applied to date type field")
```

It's rather intense, it'll just notify schema producers in the meantime and then upgrade after a few days.