### PR TITLE
Handle unavailability of remote platforms

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,8 @@ jobs:
   fetch:
     docker:
       - image: circleci/python:3.7
+    environment:
+      REPOS_CACHE_FILE: cache/repos
     working_directory: ~/repo/aggregateur
     steps:
       - checkout:
@@ -26,16 +28,27 @@ jobs:
           command: |
             echo "fr_FR.UTF-8 UTF-8" | sudo tee -a /etc/locale.gen
             sudo locale-gen
+      - restore_cache:
+          keys:
+          - v1-repos-{{ checksum $REPOS_CACHE_FILE }}
       - run:
           name: Create folders
           command: |
-            mkdir repos
+            mkdir -p repos
             rm -rf data
       - run:
           name: Fetch remote repositories
           command: |
             . venv/bin/activate
             python main.py
+      - run:
+          name: Compute checksum of repos
+          command: |
+            find -s repos -type f -exec md5sum {} \; | md5sum > $REPOS_CACHE_FILE
+      - save_cache:
+          paths:
+            - ./repos
+          key: v1-repos-{{ checksum $REPOS_CACHE_FILE }}
       - run:
           name: Fetch schema issues
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,6 @@ jobs:
   fetch:
     docker:
       - image: circleci/python:3.7
-    environment:
-      REPOS_CACHE_FILE: cache/repos
     working_directory: ~/repo/aggregateur
     steps:
       - checkout:
@@ -30,7 +28,7 @@ jobs:
             sudo locale-gen
       - restore_cache:
           keys:
-          - v1-repos-{{ checksum $REPOS_CACHE_FILE }}
+          - v1-repos-{{ checksum "cache/repos" }}
       - run:
           name: Create folders
           command: |
@@ -44,11 +42,11 @@ jobs:
       - run:
           name: Compute checksum of repos
           command: |
-            find -s repos -type f -exec md5sum {} \; | md5sum > $REPOS_CACHE_FILE
+            find -s repos -type f -exec md5sum {} \; | md5sum > "cache/repos"
       - save_cache:
           paths:
             - ./repos
-          key: v1-repos-{{ checksum $REPOS_CACHE_FILE }}
+          key: v1-repos-{{ checksum "cache/repos" }}
       - run:
           name: Fetch schema issues
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
       - run:
           name: Compute checksum of repos
           command: |
-            find -s repos -type f -exec md5sum {} \; | md5sum > "cache/repos"
+            find repos -type f -exec md5sum {} \; | sort -k 2 | md5sum > "cache/repos"
       - save_cache:
           paths:
             - ./repos

--- a/aggregateur/main.py
+++ b/aggregateur/main.py
@@ -143,9 +143,13 @@ class Repo(object):
         try:
             if os.path.isdir(self.clone_dir):
                 git_repo = GitRepo(self.clone_dir)
-                git_repo.remotes.origin.pull("refs/heads/master:refs/heads/origin")
+                git_repo.remotes.origin.pull(
+                    "refs/heads/master:refs/heads/origin", kill_after_timeout=10
+                )
             else:
-                git_repo = GitRepo.clone_from(self.git_url, self.clone_dir)
+                git_repo = GitRepo.clone_from(
+                    self.git_url, self.clone_dir, kill_after_timeout=10
+                )
         except GitError:
             raise exceptions.GitException(self, "Cannot clone or pull Git repository")
 


### PR DESCRIPTION
The goal of this PR is to handle when some remote Git platforms are down. Right now, when it happens, the build hangs out and fails. If the platform is up, we could, in some cases, even unpublish schemas because of a temporary down period.

The goal of this PR is to prevent this. The plan is to introduce a timeout for pulls and clones and to cache Git folders on CircleCI. In case of an issue, the cached Git version will be used to validate existing tags and schemas, while still logging an error and sending an email to producers (because an exception will be thrown and caught when pull/clone will fail).