### PR TITLE
List only valid tags

### DIFF
--- a/aggregateur/main.py
+++ b/aggregateur/main.py
@@ -158,7 +158,18 @@ class Repo(object):
     def tags(self):
         if self.git_repo is None or len(self.git_repo.tags) == 0:
             raise exceptions.NoTagsException(self, "Cannot found tags")
-        versions = [self.parse_version(t.name) for t in self.git_repo.tags]
+
+        # Build a list of valid version names only.
+        # Raise an exception only if the most recent
+        # version name is invalid.
+        versions = []
+        for tag in self.git_repo.tags:
+            try:
+                versions.append(self.parse_version(tag.name))
+            except exceptions.InvalidVersionException as e:
+                if tag == self.git_repo.tags[-1]:
+                    raise e
+
         return sorted(versions, key=cmp_to_key(SemverCmp))
 
     def latest_valid_tag(self):

--- a/aggregateur/repertoires.yml
+++ b/aggregateur/repertoires.yml
@@ -50,4 +50,7 @@ dae:
   url: https://gitlab.com/arsante/atlasante/schema-dae.git
   type: tableschema
   email: contact@geodae.sante.gouv.fr
-  
+prenoms:
+  url: https://github.com/CharlesNepote/liste-prenoms-nouveaux-nes.git
+  type: tableschema
+  email: charles.nepote@fing.org


### PR DESCRIPTION
Fixes #71.

Previously, we were unable to validate Git repositories with some invalid tag names (not adhering to semver). This happened for the prenoms repo, with the following tags:

![image](https://user-images.githubusercontent.com/295709/75294578-cfe9d180-57f6-11ea-8f83-940af32e3d31.png)

The beta tags were invalid, in semver it should have been `0.5-beta`.

This tag name error made the whole repository invalid, which is really too strict. Now, the `tags` method builds a list of only valid tags and raises an exception only when the latest tag has an invalid name, so that the producer has a chance to fix it.