### PR TITLE
Don't run job at night (FR time)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,7 @@ workflows:
   cron_fetch:
     triggers:
       - schedule:
-          cron: "0 * * * *"
+          cron: "0 7-19 * * *"
           filters:
             branches:
               only:


### PR DESCRIPTION
People are not likely going to update their schemas at night. And it can wait.

Let's not use CircleCI containers at night.