### PR TITLE
Add consolidation tags in schemas.yml

### DIFF
--- a/aggregateur/static/consolidation_tags.yml
+++ b/aggregateur/static/consolidation_tags.yml
@@ -1,0 +1,6 @@
+etalab/schema-irve:
+  - irve
+etalab/schema-lieux-covoiturage:
+  - covoiturage
+etalab/schema-stationnement:
+  - stationnement


### PR DESCRIPTION
Schemas often have an indication in the README that a consolidation is in place if you add a specific tag on a data.gouv.fr dataset.

In order to facilitate integration with data.gouv.fr, we need to expose this information in a machine-readable format. I've added another property to the schemas.yml file, [exposed over HTTP](https://schema.data.gouv.fr/schemas/schemas.yml).

The `metadata` method was duplicated in 2 classes, I've moved it to the parent class.