### PR TITLE
Ajout du schéma des données de questionnaires d'orientation Covid-19

### DIFF
--- a/aggregateur/repertoires.yml
+++ b/aggregateur/repertoires.yml
@@ -54,3 +54,7 @@ prenoms:
   url: https://github.com/CharlesNepote/liste-prenoms-nouveaux-nes.git
   type: tableschema
   email: charles.nepote@fing.org
+donnees-questionnaires-covid19:
+  url: https://github.com/Delegation-numerique-en-sante/covid19-algorithme-orientation-check.git
+  type: tableschema
+  email: bastien.guerry@data.gouv.fr


### PR DESCRIPTION
La documentation pour l'implémentation de questionnaires Covid-19 est [publiée](https://github.com/Delegation-numerique-en-sante/covid19-algorithme-orientation) la DNS du MSS.

Un autre dépôt contient le schéma de données de la dernière version de cette documentation (ainsi qu'un outil de validation de fichiers csv produits.)