### PR TITLE
Ajout de liens vers le dépôt GitHub

### DIFF
--- a/web/_data/footer.yml
+++ b/web/_data/footer.yml
@@ -22,4 +22,4 @@ social:
     url: https://www.twitter.com/datagouvfr
   -
     icon: github
-    url: https://github.com/etalab
+    url: https://github.com/etalab/schema.data.gouv.fr

--- a/web/collections/_documentation/ajouter-un-schema.md
+++ b/web/collections/_documentation/ajouter-un-schema.md
@@ -20,7 +20,7 @@ Etalab se réserve le droit de refuser l'ajout de schémas en motivant son refus
 ## Référencer son schéma
 Afin d'ajouter un schéma sur le site `schema.data.gouv.fr`, il faut référencer votre dépôt Git contenant ce schéma.
 
-Vous devez ajouter votre dépôt Git en modifiant le fichier [`repertoires.yml`](https://github.com/etalab/schema.data.gouv.fr/blob/master/aggregateur/repertoires.yml) en y faisant figurer les informations suivantes :
+Vous devez ajouter votre dépôt Git en modifiant le fichier [`repertoires.yml`](https://github.com/etalab/schema.data.gouv.fr/blob/master/aggregateur/repertoires.yml) du [dépôt Git disponible sur GitHub](https://github.com/{{ site.github_repository }}) en y faisant figurer les informations suivantes :
 
 - `url` : un lien HTTPS vers le dépôt Git contenant le schéma que vous souhaitez ajouter. Ce dépôt doit pouvoir être cloné depuis Internet sans authentification préalable ;
 - `type` : le type de schéma que vous ajoutez. Les types supportés sont pour le moment :


### PR DESCRIPTION
Fixes #98

- Lien supplémentaire dans la documentation
- Lien vers le dépôt dans le footer