### PR TITLE
Consolidation: add dataset_id in schemas.yml

### DIFF
--- a/aggregateur/static/consolidation.yml
+++ b/aggregateur/static/consolidation.yml
@@ -1,6 +1,12 @@
 etalab/schema-irve:
+  dataset_id: 5448d3e0c751df01f85d0572
+  tags:
   - irve
 etalab/schema-lieux-covoiturage:
+  dataset_id: 5d6eaffc8b4c417cdc452ac3
+  tags:
   - covoiturage
 etalab/schema-stationnement:
+  dataset_id: null
+  tags:
   - stationnement

--- a/aggregateur/validators.py
+++ b/aggregateur/validators.py
@@ -16,7 +16,7 @@ from table_schema_to_markdown import convert_source
 
 class BaseValidator(object):
     CHANGELOG_FILENAME = "CHANGELOG.md"
-    CONSOLIDATION_TAGS_FILENAME = "consolidation_tags.yml"
+    CONSOLIDATION_FILENAME = "consolidation.yml"
 
     def __init__(self, repo):
         super(BaseValidator, self).__init__()
@@ -56,7 +56,7 @@ class BaseValidator(object):
             "description": self.description,
             "homepage": self.homepage,
             "type": self.repo.schema_type,
-            "consolidation_tags": self.consolidation_tags(slug),
+            "consolidation": self.consolidation_data(slug),
             "email": self.repo.email,
             "version": self.repo.current_version,
             "has_changelog": self.has_changelog,
@@ -66,9 +66,9 @@ class BaseValidator(object):
     def latest_schema_url(self, path):
         return f"{config.BASE_DOMAIN}/schemas/{self.repo.slug}/latest/{path}"
 
-    def consolidation_tags(self, slug):
-        with open(os.path.join(self.static_dir, self.CONSOLIDATION_TAGS_FILENAME)) as f:
-            return yaml.safe_load(f).get(slug, [])
+    def consolidation_data(self, slug):
+        with open(os.path.join(self.static_dir, self.CONSOLIDATION_FILENAME)) as f:
+            return yaml.safe_load(f).get(slug, None)
 
     def move_files(self, files):
         if not os.path.exists(self.target_dir):

--- a/web/collections/_documentation/integration-autres-systemes.md
+++ b/web/collections/_documentation/integration-autres-systemes.md
@@ -36,8 +36,10 @@ $ tree .
 Voici un extrait du fichier `schemas.yml` (accessible à l'adresse <https://schema.data.gouv.fr/schemas/schemas.yml>) :
 ```yaml
 etalab/schema-irve:
-  consolidation_tags:
-  - irve
+  consolidation:
+    dataset_id: 5448d3e0c751df01f85d0572
+    tags:
+    - irve
   description: Spécification du fichier d'échange relatif aux données concernant la
     localisation géographique et les caractéristiques techniques des stations et des
     points de recharge pour véhicules électriques


### PR DESCRIPTION
Follow-up of previous PRs (#96, #97), this one is very similar: it adds extra metadata in `schemas.yml` to ease integration with other systems.

On top of exposing tags used for consolidation, `consolidation` (a real word in 🇫🇷  and 🇬🇧) is now a real object with a list of tags and a `dataset_id` which references a data.gouv.fr dataset ID.

Note: this a breaking change of structure for the YAML file since we're changing the name and type of a key. It's fine because it was introduced a few days ago and was likely not used by anyone else than us. Still, something to keep in mind for later.