### PR TITLE
Add consolidation details on schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,8 @@ Ce dépôt comporte plusieurs composants :
 - un aggrégateur de schémas publiés en ligne, dans le dossier `aggregateur`
 - le site web de schema.data.gouv.fr, dans le dossier `web`
 
+## Limitations connues
+- Certaines fonctionnalités JavaScript du site web ne sont [pas supportées par Internet Explorer](https://github.com/etalab/schema.data.gouv.fr/pull/102#issuecomment-624131955)
+
 ## Licence
 Le code source du répertoire est publié sous la licence MIT. Les données, disponibles dans le répertoire sont publiées sous la Licence Ouverte 2.0.

--- a/web/_includes/consolidation.html
+++ b/web/_includes/consolidation.html
@@ -1,0 +1,41 @@
+{% if include.schema_data.consolidation %}
+  {% assign schema_data = include.schema_data %}
+  {% assign consolidation = schema_data.consolidation %}
+
+  <h2>Jeu de données consolidé</h2>
+
+  <p>
+    Une consolidation de données est effectuée à partir de ce schéma. Vous pouvez retrouver le jeu de données résultant de cette consolidation sur data.gouv.fr
+  </p>
+
+  <div data-udata-dataset="{{ consolidation.dataset_id }}"></div>
+
+  <div class="js-consolidation-details consolidation-details"></div>
+
+  <script>
+    const datasetId = document.querySelector('[data-udata-dataset]').getAttribute('data-udata-dataset')
+
+    fetch('http://localhost:8000')
+      .then(response => response.json())
+      .then(data => {
+        const report = data[datasetId]
+
+        const formatter = Intl.NumberFormat()
+
+        datasetDetails = `
+          <div class="consolidation-badge">
+            <img src="${report['badge_url']}" alt="Badge de consolidation">
+          </div>
+          <p>
+            La dernière version de ce jeu de données comporte ${formatter.format(report['nb_rows'])} lignes
+            et un total de ${formatter.format(report['nb_errors'])} erreurs.
+            Le dernier rapport de validation peut être
+            <a href="${report['report_url']}" title="Rapport de validation">consulté en ligne</a>.
+          </p>
+        `
+
+        document.querySelector('.js-consolidation-details').innerHTML = datasetDetails
+      });
+  </script>
+  <script data-udata="https://www.data.gouv.fr" src="https://static.data.gouv.fr/static/oembed.js" async defer></script>
+{% endif %}

--- a/web/_includes/consolidation.html
+++ b/web/_includes/consolidation.html
@@ -1,6 +1,5 @@
 {% if include.schema_data.consolidation %}
-  {% assign schema_data = include.schema_data %}
-  {% assign consolidation = schema_data.consolidation %}
+  {% assign consolidation = include.schema_data.consolidation %}
 
   <h2>Jeu de données consolidé</h2>
 
@@ -15,7 +14,9 @@
   <script>
     const datasetId = document.querySelector('[data-udata-dataset]').getAttribute('data-udata-dataset')
 
-    fetch('http://localhost:8000')
+    const maybePluralize = (count, noun, suffix = 's') => `${count} ${noun}${count !== 1 ? suffix : ''}`
+
+    fetch('https://etalab.github.io/monitor-consolidation/report.json')
       .then(response => response.json())
       .then(data => {
         const report = data[datasetId]
@@ -27,8 +28,8 @@
             <img src="${report['badge_url']}" alt="Badge de consolidation">
           </div>
           <p>
-            La dernière version de ce jeu de données comporte ${formatter.format(report['nb_rows'])} lignes
-            et un total de ${formatter.format(report['nb_errors'])} erreurs.
+            La dernière version de ce jeu de données comporte ${maybePluralize(formatter.format(report['nb_rows']), 'ligne')}
+            et un total de ${maybePluralize(formatter.format(report['nb_errors']), 'erreur')}.
             Le dernier rapport de validation peut être
             <a href="${report['report_url']}" title="Rapport de validation">consulté en ligne</a>.
           </p>

--- a/web/_layouts/schema.html
+++ b/web/_layouts/schema.html
@@ -60,6 +60,7 @@ layout: default
       </div>
       {% endif %}
       {{ content }}
+      {% include consolidation.html schema_data=schema_data %}
     </div>
   </div>
 </section>

--- a/web/assets/css/main.css
+++ b/web/assets/css/main.css
@@ -42,3 +42,12 @@ ul {
 .edit {
   margin-top: 2em;
 }
+
+.consolidation-badge {
+  margin-bottom: 1em;
+  display: block;
+}
+
+.consolidation-details {
+  margin-top: 2em;
+}


### PR DESCRIPTION
Uses the JSON file introduced by https://github.com/etalab/monitor-consolidation/pull/3

Avoid a Jekyll rebuild daily here because JavaScript is used to get the latest consolidation information from [monitor-consolidation](https://github.com/etalab/monitor-consolidation).

## UI preview
![image](https://user-images.githubusercontent.com/295709/81017510-9fdf3000-8e30-11ea-872e-9be976529aa5.png)

I'm open to suggestions about the layout or wording! Right now, this bloc is at the very bottom of a schema page. Discoverability could be better, but I'm not sure how.