### PR TITLE
Validate generated schemas.json

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,12 @@ jobs:
             . venv/bin/activate
             python main.py
       - run:
+          name: Validate generated schemas.json
+          command: |
+            wget -O /tmp/schema-catalog.json https://opendataschema.frama.io/catalog/schema-catalog.json
+            . venv/bin/activate
+            jsonschema /tmp/schema-catalog.json -i data/schemas.json
+      - run:
           name: Compute checksum of repos
           command: |
             find repos -type f -not -path '*/\.git/*' -exec md5sum {} \; | sort -k 2 | md5sum > "cache/repos"


### PR DESCRIPTION
Closes #103

We thought that we needed to change the format of our schemas' catalog, turns out we are already compliant to the spec. I've added a check in CI to check this at every build.

I have no idea why CircleCI statutes are not reported here. [Builds ran successfully](https://circleci.com/gh/etalab/schema.data.gouv.fr/tree/check-schema-catalog) and the settings look okay to me on GitHub. Do you have an idea @abulte?