### PR TITLE
Support evolving schemas over versions

### DIFF
--- a/aggregateur/validators.py
+++ b/aggregateur/validators.py
@@ -63,8 +63,8 @@ class BaseValidator(object):
             "schemas": self.schemas_metadata(),
         }
 
-    def latest_schema_url(self, path):
-        return f"{config.BASE_DOMAIN}/schemas/{self.repo.slug}/{self.repo.latest_valid_version}/{path}"
+    def schema_url(self, path):
+        return f"{config.BASE_DOMAIN}/schemas/{self.repo.slug}/{self.repo.current_version}/{path}"
 
     def consolidation_data(self, slug):
         with open(os.path.join(self.static_dir, self.CONSOLIDATION_FILENAME)) as f:
@@ -189,7 +189,7 @@ class XsdSchemaValidator(BaseValidator):
                     "path": path,
                     "original_path": schema["path"],
                     "title": schema["title"],
-                    "latest_url": self.latest_schema_url(path),
+                    "latest_url": self.schema_url(path),
                 }
             )
 
@@ -274,7 +274,7 @@ class TableSchemaValidator(BaseValidator):
                 "path": self.SCHEMA_FILENAME,
                 "original_path": self.SCHEMA_FILENAME,
                 "title": self.title,
-                "latest_url": self.latest_schema_url(self.SCHEMA_FILENAME),
+                "latest_url": self.schema_url(self.SCHEMA_FILENAME),
             }
         ]
 

--- a/web/_layouts/schema.html
+++ b/web/_layouts/schema.html
@@ -28,7 +28,11 @@ layout: default
           <li><a href="{{ slug | append: '/latest/changelog.html' | relative_url }}">Changements sur ce schéma</a></li>
           {% endif %}
           {% for schema in schema_data.schemas %}
-          <li><a href="{{ '/schemas/' | append: slug | append: '/' | append: page.version | append: '/' | append: schema.path | relative_url }}">Schéma {{ schema.title }} {{ page.version }} (format {{ schema_data.type }})</a></li>
+            {% if schema.versions contains page.version %}
+            <li>
+              <a href="{{ '/schemas/' | append: slug | append: '/' | append: page.version | append: '/' | append: schema.path | relative_url }}">Schéma {{ schema.title }} {{ page.version }} (format {{ schema_data.type }})</a>
+            </li>
+            {% endif %}
           {% endfor %}
           <li><a href="{{ schema_data.homepage }}" title="Page d'accueil du schéma">Répertoire Git du schéma</a></li>
           <li>Contact : {{ schema_data.email }}</li>

--- a/web/collections/_documentation/integration-autres-systemes.md
+++ b/web/collections/_documentation/integration-autres-systemes.md
@@ -52,6 +52,10 @@ etalab/schema-irve:
     original_path: schema.json
     path: schema.json
     title: Schéma IRVE
+    versions:
+    - 1.0.0
+    - 1.0.1
+    - 1.0.2
   title: Schéma IRVE
   type: tableschema
   versions:


### PR DESCRIPTION
Fixes #109 

This PR includes a fix for the metadata and the web UI.

New `schemas.yml` for commande publique. Note the new `versions` array in the `schemas` key.

```yaml
139bercy/format-commande-publique:
  consolidation: null
  description: Données de tous les marchés supérieurs à 25 000 euros émanant de la
    commande publique
  email: info@data.gouv.fr
  has_changelog: false
  homepage: https://github.com/etalab/format-commande-publique
  latest_version: 1.5.0
  schemas:
  - latest_url: https://schema.data.gouv.fr/schemas/139bercy/format-commande-publique/1.3.0/contrats-concessions.json
    original_path: schémas/json/contrats-concessions.json
    path: contrats-concessions.json
    title: Contrats de concessions
    versions:
    - 1.3.0
  - latest_url: https://schema.data.gouv.fr/schemas/139bercy/format-commande-publique/1.3.0/marchés.json
    original_path: schémas/json/marchés.json
    path: marchés.json
    title: Marchés
    versions:
    - 1.3.0
  - latest_url: https://schema.data.gouv.fr/schemas/139bercy/format-commande-publique/1.5.0/marches.json
    original_path: marches.json
    path: marches.json
    title: Contrats de commande publique JSON
    versions:
    - 1.4.0
    - 1.5.0
  title: Données essentielles des marchés publics français
  type: jsonschema
  versions:
  - 1.3.0
  - 1.4.0
  - 1.5.0
```