### PR TITLE
Bouton lire documentation

### DIFF
--- a/web/_layouts/schema.html
+++ b/web/_layouts/schema.html
@@ -21,9 +21,6 @@ layout: default
       {% endif %}
       <div class="text-quote">
         <ul>
-          {% if schema_data.type == "tableschema" %}
-          <li><a href="{{ slug | append: '/' | append: page.version | append: '/documentation.html' | relative_url }}">Documentation du modèle de données</a></li>
-          {% endif %}
           {% if schema_data.has_changelog %}
           <li><a href="{{ slug | append: '/latest/changelog.html' | relative_url }}">Changements sur ce schéma</a></li>
           {% endif %}
@@ -53,10 +50,16 @@ layout: default
 
       {% if schema_data.type == "tableschema" %}
       <div class="form__group" style="margin-top: 3em">
-        <a href="{{ 'https://csv-gg.etalab.studio/?schema=' | append: slug }}" title="Saisir des données" style="margin-right: 1em" class="button icon-button">
+        <a href="{{ slug | append: '/' | append: page.version | append: '/documentation.html' | relative_url }}" title="Documentation du modèle de données" class="button icon-button">
+          <svg class="icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M4 22v-20h16v11.543c0 4.107-6 2.457-6 2.457s1.518 6-2.638 6h-7.362zm18-7.614v-14.386h-20v24h10.189c3.163 0 9.811-7.223 9.811-9.614zm-5-1.386h-10v-1h10v1zm0-4h-10v1h10v-1zm0-3h-10v1h10v-1z"/></svg>
+          Lire la documentation
+        </a>
+
+        <a href="{{ 'https://csv-gg.etalab.studio/?schema=' | append: slug }}" title="Saisir des données" class="button icon-button">
           <svg class="icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M10 13h-4v-1h4v1zm2.318-4.288l3.301 3.299-4.369.989 1.068-4.288zm11.682-5.062l-7.268 7.353-3.401-3.402 7.267-7.352 3.402 3.401zm-6 8.916v.977c0 4.107-6 2.457-6 2.457s1.518 6-2.638 6h-7.362v-20h14.056l1.977-2h-18.033v24h10.189c3.163 0 9.811-7.223 9.811-9.614v-3.843l-2 2.023z"/></svg>
           Saisir des données
         </a>
+
         <a href="{{ 'https://go.validata.fr/table-schema?schema_url=https://schema.data.gouv.fr/schemas/' | append: slug | append: '/' | append: page.version | append: '/schema.json' }}" title="Valider des données" class="button icon-button">
           <svg class="icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M20.285 2l-11.285 11.567-5.286-5.011-3.714 3.716 9 8.728 15-15.285z"/></svg>
           Valider des données


### PR DESCRIPTION
Une [remarque sur Slack](https://startups-detat.slack.com/archives/C0129TFLM3Q/p1591083039002500) faisait part du fait que la documentation n'était pas très mise en avant par rapport à la saisie ou la validation de données.

Cette PR ajoute un bouton à côté des autres.

![image](https://user-images.githubusercontent.com/295709/83579294-da5aec00-a506-11ea-8da9-28a54ad1227b.png)
