### PR TITLE
Handle timeout from remote Git platforms

### DIFF
--- a/aggregateur/main.py
+++ b/aggregateur/main.py
@@ -166,7 +166,7 @@ class Repo(object):
             )
 
         try:
-            r = requests.head(self.git_url, allow_redirects=True, timeout=5)
+            r = requests.head(self.git_url, allow_redirects=True, timeout=15)
             return r.status_code == requests.codes.ok
         except requests.exceptions.RequestException:
             return False

--- a/aggregateur/main.py
+++ b/aggregateur/main.py
@@ -184,7 +184,7 @@ class Repo(object):
 
     def tags(self):
         if self.git_repo is None or len(self.git_repo.tags) == 0:
-            raise exceptions.NoTagsException(self, "Cannot found tags")
+            raise exceptions.NoTagsException(self, "Cannot find tags")
 
         # Build a list of valid version names only.
         # Raise an exception only if the most recent

--- a/aggregateur/main.py
+++ b/aggregateur/main.py
@@ -160,6 +160,11 @@ class Repo(object):
             raise NotImplementedError
 
     def remote_available(self):
+        if not self.git_url.startswith("http"):
+            raise NotImplementedError(
+                f"Can only check remote are available over HTTP. git_url is {git_url}"
+            )
+
         try:
             r = requests.head(self.git_url, allow_redirects=True, timeout=5)
             return r.status_code == requests.codes.ok

--- a/aggregateur/requirements.txt
+++ b/aggregateur/requirements.txt
@@ -9,4 +9,3 @@ table_schema_to_markdown==0.3.1
 lxml==4.5.0
 jsonschema==3.2.0
 requests==2.23.0
-timeout-decorator==0.4.1

--- a/aggregateur/requirements.txt
+++ b/aggregateur/requirements.txt
@@ -9,3 +9,4 @@ table_schema_to_markdown==0.3.1
 lxml==4.5.0
 jsonschema==3.2.0
 requests==2.23.0
+timeout-decorator==0.4.1


### PR DESCRIPTION
Follow up of #85. The argument `kill_after_timeout` passed to GitPython was not effective.

According to the documentation, this argument is ignored when commands are running as processes. After looking at the source code, the fetch, pull and clone commands run as processes and therefore this argument has no effect. https://github.com/gitpython-developers/GitPython/blob/9b7839e6b55953ddac7e8f13b2f9e2fa2dea528b/git/cmd.py#L656-L664

I tried to replace the timeout logic with a 3rd party library, without success: Git commands are started as subprocesses and it's hard to track down and timeout these. This was my first implementation in the first commit. Then, I switched to a `socket` version, checking if the host is available over HTTPS.

Logic when a remote Git platform is unavailable.
- Git repositories are restored from latest cache on disk
- for each repo, try to connect to remote Git platform
  - ok: git fetch / git reset hard origin/master
  - ko: skip fetch, use local cache to browse tags to validate schemas. Send an email saying that clone/pull was not possible