### PR TITLE
Bump tableschema to 1.19.2

### DIFF
--- a/aggregateur/requirements.txt
+++ b/aggregateur/requirements.txt
@@ -1,7 +1,7 @@
 GitPython==3.0.7
 git-url-parse==1.2.2
 semver==2.9.1
-tableschema==1.12.4
+tableschema==1.19.2
 PyYAML==5.3
 mailjet-rest==1.3.3
 python-frontmatter==0.5.0


### PR DESCRIPTION
Bump TableSchema dependency to latest available version, 1.19.2

This upgrade will have an effect on schemas that are not fully valid according to the specification. Some schemas (DAE for example) specify constraints that are not recognised by the spec, meaning they're not enforced. Previously it was just ignored, now the schemas will be counted as invalid. This will lead to the removal of some versions or the disappearance of some schemas if they only have invalid schemas for every published version. Pull requests have been made/producers have been contacted in order to help them fix their issues.

See #84