### PR TITLE
Add generic schema support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   fetch:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
     working_directory: ~/project/aggregateur
     steps:
       - checkout:

--- a/aggregateur/main.py
+++ b/aggregateur/main.py
@@ -5,7 +5,12 @@ from functools import cmp_to_key
 
 import exceptions
 from config import BASE_DOMAIN
-from validators import TableSchemaValidator, XsdSchemaValidator, JsonSchemaValidator
+from validators import (
+    TableSchemaValidator,
+    XsdSchemaValidator,
+    JsonSchemaValidator,
+    GenericValidator,
+)
 from notifications import EmailNotification
 from errors import ErrorBag, ErrorsCache
 
@@ -101,7 +106,7 @@ class Metadata(object):
 
 
 class Repo(object):
-    SCHEMA_TYPES = ["tableschema", "xsd", "jsonschema"]
+    SCHEMA_TYPES = ["tableschema", "xsd", "jsonschema", "generic"]
 
     def __init__(self, git_url, email, schema_type):
         super(Repo, self).__init__()
@@ -156,6 +161,8 @@ class Repo(object):
             return XsdSchemaValidator(self)
         elif self.schema_type == "jsonschema":
             return JsonSchemaValidator(self)
+        elif self.schema_type == "generic":
+            return GenericValidator(self)
         else:
             raise NotImplementedError
 

--- a/aggregateur/repertoires.yml
+++ b/aggregateur/repertoires.yml
@@ -54,3 +54,7 @@ prenoms:
   url: https://github.com/CharlesNepote/liste-prenoms-nouveaux-nes.git
   type: tableschema
   email: charles.nepote@fing.org
+generic-example:
+  url: https://github.com/abulte/generic-schema.git
+  type: generic
+  email: alexandre@example.com

--- a/aggregateur/repertoires.yml
+++ b/aggregateur/repertoires.yml
@@ -54,7 +54,3 @@ prenoms:
   url: https://github.com/CharlesNepote/liste-prenoms-nouveaux-nes.git
   type: tableschema
   email: charles.nepote@fing.org
-generic-example:
-  url: https://github.com/abulte/generic-schema.git
-  type: generic
-  email: alexandre@example.com

--- a/aggregateur/validators.py
+++ b/aggregateur/validators.py
@@ -404,13 +404,24 @@ class GenericValidator(BaseValidator):
             )
             raise exceptions.InvalidSchemaException(self.repo, message)
 
+    def open_schema_file(self):
+        data = None
+        with open(self.filepath(self.SCHEMA_FILENAME)) as f:
+            data = yaml.safe_load(f)
+        return data
+
     def check_schema(self, filename):
-        return True
+        try:
+            self.open_schema_file()
+        except yaml.error.YAMLError as e:
+            message = "Yaml file not valid. Error: %s" % (
+                repr(e),
+            )
+            raise exceptions.InvalidSchemaException(self.repo, message)
 
     def get_schema_data(self):
         if self.schema_data is not None:
             return self.schema_data
 
-        with open(self.filepath(self.SCHEMA_FILENAME)) as f:
-            self.schema_data = yaml.safe_load(f)
+        self.schema_data = self.open_schema_file()
         return self.schema_data

--- a/aggregateur/validators.py
+++ b/aggregateur/validators.py
@@ -382,7 +382,7 @@ class GenericValidator(BaseValidator):
 
     def extract(self):
         files = {
-            self.SCHEMA_FILENAME: self.filepath_or_none(self.SCHEMA_FILENAME),
+            self.SCHEMA_FILENAME: self.filepath(self.SCHEMA_FILENAME),
             "README.md": self.filepath_or_none("README.md"),
             "SEE_ALSO.md": self.filepath_or_none("SEE_ALSO.md"),
             "CONTEXT.md": self.filepath_or_none("CONTEXT.md"),

--- a/aggregateur/validators.py
+++ b/aggregateur/validators.py
@@ -389,9 +389,9 @@ class GenericValidator(BaseValidator):
         }
 
         if self.is_latest_version():
-            files[self.CHANGELOG_FILENAME] = self.filepath_or_none(
-                self.CHANGELOG_FILENAME
-            )
+            changelog_path = self.filepath_or_none(self.CHANGELOG_FILENAME)
+            files[self.CHANGELOG_FILENAME] = changelog_path
+            self.has_changelog = changelog_path is not None
 
         self.move_files(files)
 

--- a/aggregateur/validators.py
+++ b/aggregateur/validators.py
@@ -7,6 +7,7 @@ import yaml
 import tableschema
 import jsonschema
 import frontmatter
+from functools import cached_property
 from lxml import etree
 
 import config

--- a/web/collections/_documentation/ajouter-un-schema.md
+++ b/web/collections/_documentation/ajouter-un-schema.md
@@ -27,7 +27,7 @@ Vous devez ajouter votre dépôt Git en modifiant le fichier [`repertoires.yml`]
     + `tableschema`, pour un schéma au format [Table Schema](https://frictionlessdata.io/specs/table-schema/)
     + `xsd`, pour un schéma au format [XML Schema Definition](https://www.w3.org/TR/xmlschema11-1/) (XSD)
     + `jsonschema`, pour un schéma au format [JSON Schema](https://json-schema.org/)
-    + `generic`, pour un schéma qui ne correspond à aucun autre type supporté
+    + `generic`, pour un schéma qui ne correspond à aucun autre type supporté — aucune validation du schéma ne sera alors effectuée, seule la documentation sera affichée sur le site
 - `email` : une adresse de courriel qui sera utilisée en cas d'erreurs lors de la validation et de l'intégration de votre schéma.
 
 Voici un exemple complet pour ajouter le schéma decp-dpa, au format Table Schema, maintenu par l'équipe de data.gouv.fr.

--- a/web/collections/_documentation/ajouter-un-schema.md
+++ b/web/collections/_documentation/ajouter-un-schema.md
@@ -27,6 +27,7 @@ Vous devez ajouter votre dépôt Git en modifiant le fichier [`repertoires.yml`]
     + `tableschema`, pour un schéma au format [Table Schema](https://frictionlessdata.io/specs/table-schema/)
     + `xsd`, pour un schéma au format [XML Schema Definition](https://www.w3.org/TR/xmlschema11-1/) (XSD)
     + `jsonschema`, pour un schéma au format [JSON Schema](https://json-schema.org/)
+    + `generic`, pour un schéma qui ne correspond à aucun autre type supporté
 - `email` : une adresse de courriel qui sera utilisée en cas d'erreurs lors de la validation et de l'intégration de votre schéma.
 
 Voici un exemple complet pour ajouter le schéma decp-dpa, au format Table Schema, maintenu par l'équipe de data.gouv.fr.

--- a/web/collections/_documentation/validation-schemas.md
+++ b/web/collections/_documentation/validation-schemas.md
@@ -115,3 +115,18 @@ schemas:
     path: "schemas/bar.json"
     title: "Une description de ce sous-schéma"
 ```
+
+## Validations spécifiques au format générique
+
+Les dépôts contenant des schémas au format générique subissent les validations supplémentaires suivantes :
+
+- le dépôt doit comporter un fichier `schema.yml` à la racine du dépôt décrivant le schéma ;
+- ce fichier doit être un Yaml valide.
+
+Le fichier `schema.yml` doit avoir le format suivant :
+```yaml
+title: Mon schéma très générique
+description: Mon schéma très générique est vraiment très très bien.
+homepage: https://github.com/example/generic-schema
+version: 1.0.0
+```

--- a/web/collections/_documentation/validation-schemas.md
+++ b/web/collections/_documentation/validation-schemas.md
@@ -118,6 +118,8 @@ schemas:
 
 ## Validations spécifiques au format générique
 
+**Ce type de schéma est considéré comme un mode "dégradé". Il n'est à utiliser que lorsque le schéma à référencer ne peut possiblement pas être raccroché à un standard déjà supporté par schema.data.gouv.fr ou dont le support pourrait être implémenté**. Seule la documentation sera générée et aucun contrôle ne sera effectué sur la validité du schéma référencé.
+
 Les dépôts contenant des schémas au format générique subissent les validations supplémentaires suivantes :
 
 - le dépôt doit comporter un fichier `schema.yml` à la racine du dépôt décrivant le schéma ;


### PR DESCRIPTION
This a quick attempt at supporting a generic schema.

The idea is to have a very basic repo (eg https://github.com/abulte/generic-schema) describing the schema, but w/ no data on the schema itself (tableschema file...). This would allow us to reference schemas not supported by our validation mechanism — maybe because they're not based on a technical standard (eg BAL). The schema would have its own page on schema.data.gouv.fr and could be made available on data.gouv.fr too.

I did not go through the hoops of setting up Ruby on my machine so the web part is untested. I'm unsure about what to commit (`aggregateur/(data|cache)`? `web`?) so I kept it to a minimum.

`python main.py` run w/o error.