### PR TITLE
Add link to datasets on datagouv

### DIFF
--- a/web/_includes/datasets.html
+++ b/web/_includes/datasets.html
@@ -1,4 +1,4 @@
-{% if include.type == "tableschema" %}
+{% if include.type == "tableschema" or include.type == "generic" %}
 
   <div class="js-datasets-datagouv"></div>
 

--- a/web/_includes/datasets.html
+++ b/web/_includes/datasets.html
@@ -1,0 +1,30 @@
+{% if include.type == "tableschema" %}
+
+  <div class="js-datasets-datagouv"></div>
+
+  <script>
+    const schema = "{{ include.slug }}"
+
+    fetch(`https://www.data.gouv.fr/api/1/datasets/?schema=${schema}`)
+      .then(response => response.json())
+      .then(data => {
+        const nbDatasets = data["total"]
+
+        content = `
+          <h2 id="jeux-de-donnees-sur-datagouvfr">Jeux de données sur data.gouv.fr</h2>
+
+          <p>
+            Il est possible de spécifier qu'une ressource d'un jeu de données présent
+            sur <a href="https://www.data.gouv.fr" title="Site web data.gouv.fr">data.gouv.fr</a>
+            respecte un schéma depuis l'interface d'administration. Retrouvez
+            <a href="https://www.data.gouv.fr/fr/datasets/?schema=${schema}" title="Jeux de données du schéma ${schema}">
+            ${Intl.NumberFormat().format(nbDatasets)} jeux de données</a>
+            ayant indiqué respecter ce schéma sur la plateforme des données ouvertes.
+          </p>
+        `
+        if (nbDatasets > 0) {
+          document.querySelector('.js-datasets-datagouv').innerHTML = content
+        }
+      });
+  </script>
+{% endif %}

--- a/web/_layouts/schema.html
+++ b/web/_layouts/schema.html
@@ -68,6 +68,7 @@ layout: default
       {% endif %}
       {{ content }}
       {% include consolidation.html schema_data=schema_data %}
+      {% include datasets.html slug=slug type=schema_data.type %}
     </div>
   </div>
 </section>


### PR DESCRIPTION
Add a link to data.gouv.fr on the schema page to find resources that have their `schema` attribute set to the current schema.

UI:
![image](https://user-images.githubusercontent.com/295709/91461540-2217b800-e857-11ea-99b3-015f109aaab4.png)

Example link for IRVE: https://www.data.gouv.fr/fr/datasets/?schema=etalab/schema-irve