### PR TITLE
Geoffrey/add doc detail

### DIFF
--- a/aggregateur/requirements.txt
+++ b/aggregateur/requirements.txt
@@ -5,7 +5,8 @@ tableschema==1.19.2
 PyYAML==5.3
 mailjet-rest==1.3.3
 python-frontmatter==0.5.0
-table_schema_to_markdown==0.4.5
+table_schema_to_markdown==0.4.6
 lxml==4.5.0
 jsonschema==3.2.0
 requests==2.23.0
+Markdown==3.3.3

--- a/web/build.sh
+++ b/web/build.sh
@@ -4,7 +4,7 @@ bundle install
 wget https://github.com/etalab/schema.data.gouv.fr/archive/master.zip -O /tmp/schema.data.gouv.fr.zip
 unzip /tmp/schema.data.gouv.fr.zip -d /tmp
 rm assets/images/*
-cp -r ../aggregateur/assets/. assets/images/
+cp -r /tmp/schema.data.gouv.fr-master/aggregateur/assets/. assets/images/
 cp -r /tmp/schema.data.gouv.fr-master/aggregateur/data/. collections/_schemas/
 cp /tmp/schema.data.gouv.fr-master/aggregateur/data/schemas.yml _data/
 cp /tmp/schema.data.gouv.fr-master/aggregateur/data/issues.yml _data/

--- a/web/build.sh
+++ b/web/build.sh
@@ -3,6 +3,8 @@ bundle install
 
 wget https://github.com/etalab/schema.data.gouv.fr/archive/master.zip -O /tmp/schema.data.gouv.fr.zip
 unzip /tmp/schema.data.gouv.fr.zip -d /tmp
+rm assets/images/*
+cp -r ../aggregateur/assets/. assets/images/
 cp -r /tmp/schema.data.gouv.fr-master/aggregateur/data/. collections/_schemas/
 cp /tmp/schema.data.gouv.fr-master/aggregateur/data/schemas.yml _data/
 cp /tmp/schema.data.gouv.fr-master/aggregateur/data/issues.yml _data/


### PR DESCRIPTION
I add a new feature in schema.data.gouv.fr which is the possibility to link documentation to a specific field. 

In github repo of a tableschema schema, add a ```documentation``` folder and create markdown file in it with name of field (in lower case) (ex: ```id_lieu.md``` for documentation of ```id_lieu``` property). If you have images in documentation, you can add them in ```documentation/assets/``` folder. If you want to control size of images, use Kramdown syntax (https://kramdown.gettalong.org/syntax.html#images) 

Exemple of repository structure for linking ```id_lieu``` property to a specific page which is refering to an asset (here ```lieu.png```)

```
.
├── CHANGELOG.md
├── LICENSE.md
├── README.md
├── documentation
│   ├── assets
│   │   └── lieu.png
│   └── id_lieu.md
├── exemple-invalide.csv
├── exemple-valide.csv
├── exemple-valide.xls
├── requirements.txt
└── schema.json
```

Link for detailed page will appear in documentation page of schema ("En savoir plus sur ...") : 

<img width="623" alt="Capture d’écran 2020-12-12 à 16 33 15" src="https://user-images.githubusercontent.com/3721168/101988094-01556000-3c98-11eb-91cb-435b8499e5aa.png">

And with this example of id_lieu.md : 

```
# test id_lieu

![image](./assets/lieu.png){:height="36px" width="36px"}

## This is a second test

![image](./assets/lieu.png)
```

Result will be displayed by clicking on the detail link : 

<img width="615" alt="Capture d’écran 2020-12-12 à 16 33 46" src="https://user-images.githubusercontent.com/3721168/101988158-3b266680-3c98-11eb-914f-da40dabb9666.png">



