### PR TITLE
Geoffrey/add external links to schema

### DIFF
--- a/aggregateur/main.py
+++ b/aggregateur/main.py
@@ -108,13 +108,15 @@ class Metadata(object):
 class Repo(object):
     SCHEMA_TYPES = ["tableschema", "xsd", "jsonschema", "generic"]
 
-    def __init__(self, git_url, email, schema_type):
+    def __init__(self, git_url, email, schema_type, external_doc, external_tool):
         super(Repo, self).__init__()
         parsed_git = giturlparse.parse(git_url)
         self.git_url = git_url
         self.owner = self.find_owner(parsed_git)
         self.name = parsed_git.name
         self.email = email
+        self.external_doc = external_doc
+        self.external_tool = external_tool
         if os.path.isdir(self.clone_dir):
             self.git_repo = GitRepo(self.clone_dir)
         else:
@@ -274,7 +276,17 @@ with open("repertoires.yml", "r") as f:
 metadata = Metadata()
 for repertoire_slug, conf in config.items():
     try:
-        repo = Repo(conf["url"], conf["email"], conf["type"])
+        if("external_doc" not in conf):
+            external_doc = None
+        else:
+            external_doc = conf['external_doc']
+        if("external_tool" not in conf):
+            external_tool = None
+        else:
+            external_tool = conf['external_tool']
+        
+        repo = Repo(conf["url"], conf["email"], conf["type"], external_doc,external_tool)
+        
         repo.clone_or_pull()
         tags = repo.tags()
     except exceptions.ValidationException as e:

--- a/aggregateur/validators.py
+++ b/aggregateur/validators.py
@@ -90,6 +90,8 @@ class BaseValidator(object):
             "type": self.repo.schema_type,
             "consolidation": self.consolidation_data(slug),
             "email": self.repo.email,
+            "external_doc":self.repo.external_doc,
+            "external_tool":self.repo.external_tool,
             "version": self.repo.current_version,
             "has_changelog": self.has_changelog,
             "schemas": self.schemas_metadata(),

--- a/web/_layouts/schema.html
+++ b/web/_layouts/schema.html
@@ -49,6 +49,29 @@ layout: default
       </div>
 
       {% if schema_data.type == "tableschema" %}
+      {% if schema_data.external_doc %}
+      <div class="form__group" style="margin-top: 3em">
+        <a style="min-width: 48%" href="{{ slug | append: '/' | append: page.version | append: '/documentation.html' | relative_url }}" title="Documentation du modèle de données" class="button icon-button">
+          <svg class="icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M4 22v-20h16v11.543c0 4.107-6 2.457-6 2.457s1.518 6-2.638 6h-7.362zm18-7.614v-14.386h-20v24h10.189c3.163 0 9.811-7.223 9.811-9.614zm-5-1.386h-10v-1h10v1zm0-4h-10v1h10v-1zm0-3h-10v1h10v-1z"/></svg>
+          Documentation technique
+        </a>
+
+        <a style="min-width: 48%" href="{{ schema_data.external_doc }}" title="Valider des données" class="button icon-button">
+          <svg class="icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M4 22v-20h16v11.543c0 4.107-6 2.457-6 2.457s1.518 6-2.638 6h-7.362zm18-7.614v-14.386h-20v24h10.189c3.163 0 9.811-7.223 9.811-9.614zm-5-1.386h-10v-1h10v1zm0-4h-10v1h10v-1zm0-3h-10v1h10v-1z"/></svg>
+          Documentation externe
+        </a>
+      </div><br/>
+      <div>
+        <a style="min-width: 48%" href="{{ 'https://csv-gg.etalab.studio/?schema=' | append: slug }}" title="Saisir des données" class="button icon-button">
+          <svg class="icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M10 13h-4v-1h4v1zm2.318-4.288l3.301 3.299-4.369.989 1.068-4.288zm11.682-5.062l-7.268 7.353-3.401-3.402 7.267-7.352 3.402 3.401zm-6 8.916v.977c0 4.107-6 2.457-6 2.457s1.518 6-2.638 6h-7.362v-20h14.056l1.977-2h-18.033v24h10.189c3.163 0 9.811-7.223 9.811-9.614v-3.843l-2 2.023z"/></svg>
+          Saisir des données
+        </a>
+        <a style="min-width: 48%" href="{{ 'https://validata.etalab.studio/table-schema?schema_url=https://schema.data.gouv.fr/schemas/' | append: slug | append: '/' | append: page.version | append: '/schema.json' }}" title="Valider des données" class="button icon-button">
+          <svg class="icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M20.285 2l-11.285 11.567-5.286-5.011-3.714 3.716 9 8.728 15-15.285z"/></svg>
+          Valider des données
+        </a>
+      </div>
+      {% else %}
       <div class="form__group" style="margin-top: 3em">
         <a href="{{ slug | append: '/' | append: page.version | append: '/documentation.html' | relative_url }}" title="Documentation du modèle de données" class="button icon-button">
           <svg class="icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M4 22v-20h16v11.543c0 4.107-6 2.457-6 2.457s1.518 6-2.638 6h-7.362zm18-7.614v-14.386h-20v24h10.189c3.163 0 9.811-7.223 9.811-9.614zm-5-1.386h-10v-1h10v1zm0-4h-10v1h10v-1zm0-3h-10v1h10v-1z"/></svg>
@@ -65,6 +88,40 @@ layout: default
           Valider des données
         </a>
       </div>
+      {% endif %}
+      {% else %}
+      {% if schema_data.external_doc %}
+      {% if schema_data.external_tool %}
+      <div class="form__group" style="margin-top: 3em">
+        <a href="{{ schema_data.external_doc }}" title="Valider des données" class="button icon-button">
+          <svg class="icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M4 22v-20h16v11.543c0 4.107-6 2.457-6 2.457s1.518 6-2.638 6h-7.362zm18-7.614v-14.386h-20v24h10.189c3.163 0 9.811-7.223 9.811-9.614zm-5-1.386h-10v-1h10v1zm0-4h-10v1h10v-1zm0-3h-10v1h10v-1z"/></svg>
+          Documentation externe
+        </a>
+        <a href="{{ schema_data.external_tool }}" title="Valider des données" class="button icon-button">
+          <svg class="icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M10 13h-4v-1h4v1zm2.318-4.288l3.301 3.299-4.369.989 1.068-4.288zm11.682-5.062l-7.268 7.353-3.401-3.402 7.267-7.352 3.402 3.401zm-6 8.916v.977c0 4.107-6 2.457-6 2.457s1.518 6-2.638 6h-7.362v-20h14.056l1.977-2h-18.033v24h10.189c3.163 0 9.811-7.223 9.811-9.614v-3.843l-2 2.023z"/></svg>
+          Saisir des données
+        </a>
+      </div>
+      {% else %}      
+      <div class="form__group" style="margin-top: 3em">
+        <a href="{{ schema_data.external_doc }}" title="Valider des données" class="button icon-button">
+          <svg class="icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M4 22v-20h16v11.543c0 4.107-6 2.457-6 2.457s1.518 6-2.638 6h-7.362zm18-7.614v-14.386h-20v24h10.189c3.163 0 9.811-7.223 9.811-9.614zm-5-1.386h-10v-1h10v1zm0-4h-10v1h10v-1zm0-3h-10v1h10v-1z"/></svg>
+          Documentation externe
+        </a>
+      </div>
+      {% endif %}
+      {% endif %}
+      {% unless schema_data.external_doc %}
+      {% if schema_data.external_tool %}
+      <div class="form__group" style="margin-top: 3em">
+        <a href="{{ schema_data.external_tool }}" title="Valider des données" class="button icon-button">
+          <svg class="icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M10 13h-4v-1h4v1zm2.318-4.288l3.301 3.299-4.369.989 1.068-4.288zm11.682-5.062l-7.268 7.353-3.401-3.402 7.267-7.352 3.402 3.401zm-6 8.916v.977c0 4.107-6 2.457-6 2.457s1.518 6-2.638 6h-7.362v-20h14.056l1.977-2h-18.033v24h10.189c3.163 0 9.811-7.223 9.811-9.614v-3.843l-2 2.023z"/></svg>
+          Saisir des données
+        </a>
+      </div>
+      {% endif %}
+      {% endunless %}
+
       {% endif %}
       {{ content }}
       {% include consolidation.html schema_data=schema_data %}


### PR DESCRIPTION
I had a new feature in schema.data.gouv.fr which is the possibility to specify an external documentation or an external data filling tool to a specific schema.

To do that, we have two add new properties in ```repertoires.yml``` in ```aggregateur``` folder. For example :

```
amenagements-cyclables:
  url: https://github.com/etalab/schema-amenagements-cyclables
  type: jsonschema
  email: contact@transport.beta.gouv.fr
  external_doc: https://ma-super-doc.com
  external_tool: https://mon-outil-de-saisie-specifique.com
``` 
These properties are non mandatory. You do not have to add these for your schema to be referenced. Furthermore, ```external_tool``` property usage is only for non-tableschema schema because we use https://csv-gg.etalab.studio/ to fill data for tableschema schema.

When these properties are filled with correct urls, buttons will appear in the schema page in schema.data.gouv.fr. 

Example 1 (tableschema example) : 

<img width="1257" alt="Capture d’écran 2020-12-15 à 18 45 05" src="https://user-images.githubusercontent.com/3721168/102251916-b771b180-3f05-11eb-85a9-1ad1a670623a.png">

Example 2 (jsonschema example) :

<img width="1036" alt="Capture d’écran 2020-12-15 à 18 44 23" src="https://user-images.githubusercontent.com/3721168/102251938-be98bf80-3f05-11eb-82ca-f32870529025.png">


