### PR TITLE
Ajout du schéma de la base d'adresse locale

### DIFF
--- a/aggregateur/main.py
+++ b/aggregateur/main.py
@@ -146,7 +146,7 @@ class Metadata(object):
 
 
 class Repo(object):
-    SCHEMA_TYPES = ["tableschema", "xsd", "jsonschema", "generic"]
+    SCHEMA_TYPES = ["tableschema", "xsd", "jsonschema", "other"]
 
     def __init__(self, git_url, email, schema_type, external_doc, external_tool):
         super(Repo, self).__init__()
@@ -203,7 +203,7 @@ class Repo(object):
             return XsdSchemaValidator(self)
         elif self.schema_type == "jsonschema":
             return JsonSchemaValidator(self)
-        elif self.schema_type == "generic":
+        elif self.schema_type == "other":
             return GenericValidator(self)
         else:
             raise NotImplementedError

--- a/aggregateur/repertoires.yml
+++ b/aggregateur/repertoires.yml
@@ -62,4 +62,9 @@ inclusion-numerique:
   url: https://github.com/etalab/schema-inclusion-numerique.git
   type: tableschema
   email: carto@aidantsconnect.beta.gouv.fr
-
+bal:
+  url: https://github.com/etalab/schema-bal
+  type: other
+  email: adresse@data.gouv.fr
+  external_doc: https://adresse.data.gouv.fr/bases-locales
+  external_tool: https://mes-adresses.data.gouv.fr/new

--- a/api/data/recommendations.json
+++ b/api/data/recommendations.json
@@ -378,7 +378,7 @@
     ]
   },
   {
-    "id": "583d869ec751df49bbc0bb7e",
+    "id": "5c4aec6c9ce2e72ff5275b6c",
     "recommendations": [
       {
         "id": "5448d3e0c751df01f85d0572",
@@ -387,7 +387,7 @@
     ]
   },
   {
-    "id": "5c4aec6c9ce2e72ff5275b6c",
+    "id": "583d869ec751df49bbc0bb7e",
     "recommendations": [
       {
         "id": "5448d3e0c751df01f85d0572",

--- a/web/build-local.sh
+++ b/web/build-local.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+bundle install
+
+#wget https://github.com/etalab/schema.data.gouv.fr/archive/master.zip -O /tmp/schema.data.gouv.fr.zip
+#unzip /tmp/schema.data.gouv.fr.zip -d /tmp
+rm assets/images/*
+cp -r ../aggregateur/assets/. assets/images/
+cp -r ../aggregateur/data/. collections/_schemas/
+cp ../aggregateur/data/schemas.yml _data/
+cp ../aggregateur/data/issues.yml _data/
+bundle exec jekyll build
+
+# Add headers' rules for Netlify
+#cp _headers _site/
+# Add redirection rules for Netlify
+#cp _redirects _site/
+
+# Add API files
+mkdir _site/api
+cp ../api/data/* _site/api
+
+# Zip the schemas folder and include it in the published website
+cd collections && mv _schemas schemas && zip -r schemas.zip schemas/ && mv schemas _schemas && mv schemas.zip ../_site/schemas/


### PR DESCRIPTION
Il s'agit du premier schéma qui n'est pas conçu avec les standards tableschema et jsonschema.

Le catalogue des schémas acceptent depuis peu la notion de schéma de type "other", ce qui est le cas ici. On ajoute également dans le répertoires deux propriétés ```external_doc``` et ```external_tool``` pour renvoyer l'utilisateur vers les outils spécifiques liés à ce schéma.
