### PR TITLE
Ajout Schema Hautes Remunerations

### DIFF
--- a/aggregateur/repertoires.yml
+++ b/aggregateur/repertoires.yml
@@ -69,3 +69,7 @@ bal:
   email: adresse@data.gouv.fr
   external_doc: https://adresse.data.gouv.fr/bases-locales
   external_tool: https://mes-adresses.data.gouv.fr/new
+hautes-remunerations:
+  url: https://github.com/etalab/schema-hautes-remunerations
+  type: tableschema
+  email: schema@data.gouv.fr


### PR DESCRIPTION
Suite à #130 et un atelier de conception mené le 3 mars 2021 entre producteurs, réutilisateurs et experts de la donnée.

Le schéma est publié sur schema.data.gouv.fr via cette PR