### PR TITLE
Add versions property to schemas.json catalog

### DIFF
--- a/aggregateur/main.py
+++ b/aggregateur/main.py
@@ -95,7 +95,7 @@ class Metadata(object):
             for v in s["versions"]:
                 version = {}
                 version["version_name"] = v
-                version["schema_url"] = "https://schema.data.gouv.fr/schemas/"+slug+"/"+v+"/"+s["path"]
+                version["schema_url"] = BASE_DOMAIN+"/schemas/"+slug+"/"+v+"/"+s["path"]
                 versions.append(version)
         return versions
 

--- a/aggregateur/main.py
+++ b/aggregateur/main.py
@@ -89,6 +89,16 @@ class Metadata(object):
         with open("data/schemas.json", "w") as f:
             json.dump(self.generate_complete_json(), f, ensure_ascii=False)
 
+    def generate_versions_json(self, details, slug):
+        versions = []
+        for s in details["schemas"]:
+            for v in s["versions"]:
+                version = {}
+                version["version_name"] = v
+                version["schema_url"] = "https://schema.data.gouv.fr/schemas/"+slug+"/"+v+"/"+s["path"]
+                versions.append(version)
+        return versions
+
     def generate_json(self):
         json_data = {
             "$schema": "https://opendataschema.frama.io/catalog/schema-catalog.json",
@@ -99,12 +109,14 @@ class Metadata(object):
         for slug, details in self.data.items():
             if details["type"] != "tableschema":
                 continue
+           
             schemas.append(
                 {
                     "name": slug,
                     "title": details["title"],
                     "description": details["description"],
                     "schema_url": self.schema_url(slug),
+                    "versions": self.generate_versions_json(details,slug)
                 }
             )
 
@@ -129,6 +141,7 @@ class Metadata(object):
                         "description": details["description"],
                         "schema_url": self.schema_url(slug),
                         "schema_type": details["type"],
+                        "versions": self.generate_versions_json(details,slug)
                     }
                 )
             else:
@@ -139,6 +152,7 @@ class Metadata(object):
                         "description": details["description"],
                         "schema_url": self.get()[slug]["schemas"][0]["latest_url"],
                         "schema_type": details["type"],
+                        "versions": self.generate_versions_json(details,slug)
                     }
 
                 )


### PR DESCRIPTION
Referring to https://framagit.org/opendataschema/catalog/-/issues/3 I added a new ```versions``` property in catalog to be able to distinguish different versions from the same schema in the catalog in itself.