### PR TITLE
Ajout du nouveau schéma pour le stationnement cyclable

### DIFF
--- a/aggregateur/repertoires.yml
+++ b/aggregateur/repertoires.yml
@@ -59,6 +59,10 @@ amenagements-cyclables:
   type: jsonschema
   email: contact@transport.beta.gouv.fr
   external_tool: https://github.com/etalab/schema-amenagements-cyclables/tree/master/tools
+stationnement-cyclable:
+  url: https://github.com/etalab/schema-stationnement-cyclable
+  type: tableschema
+  email: contact@transport.beta.gouv.fr
 inclusion-numerique:
   url: https://github.com/etalab/schema-inclusion-numerique.git
   type: tableschema


### PR DESCRIPTION
La v0.1 du schéma national pour le stationnement cyclable est disponible, elle peut être référencée sur schema.data.gouv.fr.