### PR TITLE
Changement de l'adresse contact : schéma IRVE

### DIFF
--- a/aggregateur/repertoires.yml
+++ b/aggregateur/repertoires.yml
@@ -1,7 +1,7 @@
 irve:
   url: https://github.com/etalab/schema-irve.git
   type: tableschema
-  email: schema@data.gouv.fr
+  email: contact@transport.beta.gouv.fr
 format-commande-publique:
   url: https://github.com/139bercy/format-commande-publique.git
   type: jsonschema


### PR DESCRIPTION
Changement de l'adresse contact du schéma IRVE pour mettre l'adresse : contact@transport.beta.gouv.fr