### PR TITLE
Correction test détection URL avec une version

### DIFF
--- a/site/site/.vuepress/theme/global-components/MenuSchema.vue
+++ b/site/site/.vuepress/theme/global-components/MenuSchema.vue
@@ -127,7 +127,8 @@ export default {
       if (this.$router.currentRoute.path.split('/').length > 4) {
           this.version = this.$router.currentRoute.path.split('/')[3]
       } else {
-          if(this.$router.currentRoute.path.split('/')[3].includes('.html')){
+          // URL like /etalab/schema-hautes-remunerations/0.1.0.html
+          if (this.$router.currentRoute.path.split('/')[3].match(/\d+\.\d+\.\d+\.html/)) {
               this.version = this.$router.currentRoute.path.split('/')[3].replace('.html','')
           } else {
             this.version = this.schema_infos['latest']


### PR DESCRIPTION
Suite de #196 

La condition est vraie pour des URLs finissant en `latest.html`. Utilisation d'une regex pour vérifier que la chaine ressemble bien à une version.

```js
'0.1.0.html'.match(/\d+\.\d+\.\d+\.html/)
> ['0.1.0.html', index: 0, input: '0.1.0.html', groups: undefined]
'latest.html'.match(/\d+\.\d+\.\d+\.html/)
> null
```