### PR TITLE
Exclusion IRVE 2.3.0 (après publication 2.3.1)

### DIFF
--- a/config_consolidation.yml
+++ b/config_consolidation.yml
@@ -93,6 +93,7 @@ etalab/schema-irve-statique:
   - 2.1.0
   - 2.2.0
   - 2.2.1
+  - 2.3.0
   exclude_dataset_ids:
   - 54231d4a88ee38334b5b9e1d
   - 601d660f2be2c8896f86e18d


### PR DESCRIPTION
Voir:
- https://github.com/etalab/schema-irve/releases/tag/v2.3.1